### PR TITLE
Implements select metric to StartAutoMLRequest

### DIFF
--- a/Adapter_pb2_grpc.py
+++ b/Adapter_pb2_grpc.py
@@ -6,7 +6,9 @@ import Adapter_pb2 as Adapter__pb2
 
 
 class AdapterServiceStub(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     def __init__(self, channel):
         """Constructor.
@@ -22,10 +24,14 @@ class AdapterServiceStub(object):
 
 
 class AdapterServiceServicer(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     def StartAutoML(self, request, context):
-        """Missing associated documentation comment in .proto file."""
+        """
+        Execute a new AutoML run. 
+        """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
@@ -46,7 +52,9 @@ def add_AdapterServiceServicer_to_server(servicer, server):
 
  # This class is part of an EXPERIMENTAL API.
 class AdapterService(object):
-    """Missing associated documentation comment in .proto file."""
+    """
+    AutoML Adapter Service implementation. Service provide functionality to execute and interact with the current AutoML process.
+    """
 
     @staticmethod
     def StartAutoML(request,

--- a/AutoMLs/StructuredDataAutoML.py
+++ b/AutoMLs/StructuredDataAutoML.py
@@ -34,6 +34,11 @@ class StructuredDataAutoML(object):
         """
         self.__time_limit = 30
         self.__configuration = configuration
+
+        if self.__configuration["metric"] == "":
+            # handle empty metric field, None is the default metric parameter for AutoSklearn
+            self.__configuration["metric"] = None
+
         return
 
     def __read_training_data(self):
@@ -95,6 +100,7 @@ class StructuredDataAutoML(object):
         if self.__configuration["runtime_constraints"]["runtime_limit"] != 0:
             automl_settings.update(
                 {"time_left_for_this_task": self.__configuration["runtime_constraints"]["runtime_limit"]})
+        automl_settings.update({"metric": self.__configuration["metric"]})
         return automl_settings
 
     def __classification(self):


### PR DESCRIPTION
[#22](https://github.com/hochschule-darmstadt/MetaAutoML/issues/22) implements a new parameter "metric" in the grpc files and the adapters. This metric parameter is used to set the metric the adapter should optimize for. If the field is kept empty each adapter uses its default value.